### PR TITLE
Provide a 'More help' link to MoodleDocs in activity chooser.

### DIFF
--- a/lang/en/hotquestion.php
+++ b/lang/en/hotquestion.php
@@ -76,6 +76,7 @@ $string['inputquestion_help'] = 'Change the submit directions to what you want t
 $string['invalidquestion'] = 'Empty questions are ignored.';
 $string['modulename'] = 'Hot Question';
 $string['modulename_help'] = 'A Hot Question activity enables students to post and vote on posts, in response to questions asked by course teachers.';
+$string['modulename_link'] = 'mod/hotquestion/view';
 $string['modulenameplural'] = 'Hot Questions';
 $string['newround'] = 'Open a new round';
 $string['newroundsuccess'] = 'You have successfully opened a new round.';


### PR DESCRIPTION
Thanks!
That would provide such a link:
<img width="357" alt="activitychooserdocslink" src="https://user-images.githubusercontent.com/377279/60030992-36d14c80-96a4-11e9-9286-9e8ad0cd3403.png">
