### PR TITLE
Fixed invalid GROUP BY issue with MSSQL / sqlsrv databases

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -308,14 +308,14 @@ class mod_hotquestion {
             $this->currentround->endtime = 0xFFFFFFFF;  // Hack.
         }
         $params = array($this->instance->id, $this->currentround->starttime, $this->currentround->endtime);
-        return $DB->get_records_sql('SELECT q.*, count(v.voter) as votecount
+        return $DB->get_records_sql('SELECT q.id, q.hotquestion, q.content, q.userid, q.time, q.anonymous, q.approved, q.tpriority, count(v.voter) as votecount
                                      FROM {hotquestion_questions} q
                                          LEFT JOIN {hotquestion_votes} v
                                          ON v.question = q.id
                                      WHERE q.hotquestion = ?
                                         AND q.time >= ?
                                         AND q.time <= ?
-                                     GROUP BY q.id
+                                     GROUP BY q.id, q.hotquestion, q.content, q.userid, q.time, q.anonymous, q.approved, q.tpriority
                                      ORDER BY tpriority DESC, votecount DESC, q.time DESC', $params);
     }
 
@@ -372,14 +372,14 @@ class mod_hotquestion {
             $this->currentround->endtime = 0xFFFFFFFF;  // Hack.
         }
         $params = array($this->instance->id, $this->currentround->starttime, $this->currentround->endtime);
-        $questions = $DB->get_records_sql('SELECT q.*, count(v.voter) as votecount
+        $questions = $DB->get_records_sql('SELECT q.id, q.hotquestion, q.content, q.userid, q.time, q.anonymous, q.approved, q.tpriority, count(v.voter) as votecount
                                      FROM {hotquestion_questions} q
                                          LEFT JOIN {hotquestion_votes} v
                                          ON v.question = q.id
                                      WHERE q.hotquestion = ?
                                          AND q.time >= ?
                                          AND q.time <= ?
-                                     GROUP BY q.id
+                                     GROUP BY q.id, q.hotquestion, q.content, q.userid, q.time, q.anonymous, q.approved, q.tpriority
                                      ORDER BY votecount DESC, q.time DESC', $params);
 
         if ($questions) {


### PR DESCRIPTION
MSSQL requires that any non-aggregated column in a SELECT statement be included in the GROUP BY column.
This commit fixes the generic 'database error' that appears when using any MSSQL / sqlsrv database by expanding out the select wildcard and including all the non-aggregated columns in the GROUP BY statement