### PR TITLE
Set valid Maturity

### DIFF
--- a/version.php
+++ b/version.php
@@ -33,5 +33,5 @@ $plugin->version   = 2022051800;      // The current module version (Date: YYYYM
 $plugin->requires  = 2014111000;      // Requires Moodle 2.8 version.
 $plugin->cron      = 0;               // Period for cron to check this module (secs).
 $plugin->component = 'mod_hotquestion';
-$plugin->maturity  = MATURITY_BETA_RC1;
-$plugin->release   = "4.1.0 (Build: 2022051800)"; // User-friendly version number.
+$plugin->maturity  = MATURITY_RC;
+$plugin->release   = "4.1.0 (Build: 2022051800) RC1"; // User-friendly version number.


### PR DESCRIPTION
https://docs.moodle.org/dev/version.php
"Supported value is any of the predefined constants MATURITY_ALPHA, MATURITY_BETA, MATURITY_RC or MATURITY_STABLE."

Causing a lot of noise in unit test runs