### PR TITLE
Fixed 4 PHPUnit errors in tool_dataprivacy

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -168,7 +168,7 @@ class provider implements \core_privacy\local\metadata\provider,
 
         // Find users with hotquestion_question entries.
         $sql = "
-            SELECT hqq.userid
+            SELECT hq.userid
               FROM {hotquestion_questions} hq
               JOIN {hotquestion} h
                 ON h.id = hq.hotquestion


### PR DESCRIPTION
Corrected typo which fixes the following PHPUnit test errors within tool_dataprivacy:

```
1) tool_dataprivacy\expired_contexts_test::test_process_course_context_with_override_unexpired_role
Unexpected debugging() call detected.
Debugging: Error reading from database (Unknown column 'hqq.userid' in 'field list'

            SELECT DISTINCT u.id
            FROM t_user u
            JOIN (
            SELECT hqq.userid
              FROM t_hotquestion_questions hq
              JOIN t_hotquestion h
                ON h.id = hq.hotquestion
              JOIN t_course_modules cm
                ON cm.instance = h.id
               AND cm.module = ?
              JOIN t_context ctx
                ON ctx.instanceid = cm.id
               AND ctx.contextlevel = ?
             WHERE ctx.id = ?
        ) target ON u.id = target.userid
[array (
  0 => '20',
  1 => 70,
  2 => 184001,
)])
* line 293 of /lib/dml/moodle_read_slave_trait.php: call to moodle_database->query_end()
* line 1371 of /lib/dml/mysqli_native_moodle_database.php: call to mysqli_native_moodle_database->query_end()
* line 56 of /privacy/classes/local/request/userlist.php: call to mysqli_native_moodle_database->get_records_sql()
* line 183 of /mod/hotquestion/classes/privacy/provider.php: call to core_privacy\local\request\userlist->add_from_sql()
* line 8144 of /lib/moodlelib.php: call to mod_hotquestion\privacy\provider::get_users_in_context()
* line 578 of /privacy/classes/manager.php: call to component_class_callback()
* line 611 of /privacy/classes/manager.php: call to core_privacy\manager::component_class_callback()
* line 285 of /privacy/classes/manager.php: call to core_privacy\manager->handled_component_class_callback()
* line 451 of /admin/tool/dataprivacy/classes/expired_contexts_manager.php: call to core_privacy\manager->get_users_in_context()
* line 388 of /admin/tool/dataprivacy/classes/expired_contexts_manager.php: call to tool_dataprivacy\expired_contexts_manager->delete_expired_context()
* line 946 of /admin/tool/dataprivacy/tests/expired_contexts_test.php: call to tool_dataprivacy\expired_contexts_manager->process_approved_deletions()
* line 1548 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to tool_dataprivacy\expired_contexts_test->test_process_course_context_with_override_unexpired_role()
* line 1154 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 94 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 728 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 904 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 661 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 144 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 97 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 98 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 122 of /vendor/bin/phpunit: call to include()


/var/www/html/lib/phpunit/classes/advanced_testcase.php:102

2) tool_dataprivacy\expired_contexts_test::test_process_course_context_with_override_expired_role
Unexpected debugging() call detected.
Debugging: Error reading from database (Unknown column 'hqq.userid' in 'field list'

            SELECT DISTINCT u.id
            FROM t_user u
            JOIN (
            SELECT hqq.userid
              FROM t_hotquestion_questions hq
              JOIN t_hotquestion h
                ON h.id = hq.hotquestion
              JOIN t_course_modules cm
                ON cm.instance = h.id
               AND cm.module = ?
              JOIN t_context ctx
                ON ctx.instanceid = cm.id
               AND ctx.contextlevel = ?
             WHERE ctx.id = ?
        ) target ON u.id = target.userid
[array (
  0 => '20',
  1 => 70,
  2 => 184001,
)])
* line 293 of /lib/dml/moodle_read_slave_trait.php: call to moodle_database->query_end()
* line 1371 of /lib/dml/mysqli_native_moodle_database.php: call to mysqli_native_moodle_database->query_end()
* line 56 of /privacy/classes/local/request/userlist.php: call to mysqli_native_moodle_database->get_records_sql()
* line 183 of /mod/hotquestion/classes/privacy/provider.php: call to core_privacy\local\request\userlist->add_from_sql()
* line 8144 of /lib/moodlelib.php: call to mod_hotquestion\privacy\provider::get_users_in_context()
* line 578 of /privacy/classes/manager.php: call to component_class_callback()
* line 611 of /privacy/classes/manager.php: call to core_privacy\manager::component_class_callback()
* line 285 of /privacy/classes/manager.php: call to core_privacy\manager->handled_component_class_callback()
* line 451 of /admin/tool/dataprivacy/classes/expired_contexts_manager.php: call to core_privacy\manager->get_users_in_context()
* line 388 of /admin/tool/dataprivacy/classes/expired_contexts_manager.php: call to tool_dataprivacy\expired_contexts_manager->delete_expired_context()
* line 1034 of /admin/tool/dataprivacy/tests/expired_contexts_test.php: call to tool_dataprivacy\expired_contexts_manager->process_approved_deletions()
* line 1548 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to tool_dataprivacy\expired_contexts_test->test_process_course_context_with_override_expired_role()
* line 1154 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 94 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 728 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 904 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 661 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 144 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 97 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 98 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 122 of /vendor/bin/phpunit: call to include()


/var/www/html/lib/phpunit/classes/advanced_testcase.php:102

3) tool_dataprivacy\expired_contexts_test::test_process_course_context_with_user_in_both_lists
Unexpected debugging() call detected.
Debugging: Error reading from database (Unknown column 'hqq.userid' in 'field list'

            SELECT DISTINCT u.id
            FROM t_user u
            JOIN (
            SELECT hqq.userid
              FROM t_hotquestion_questions hq
              JOIN t_hotquestion h
                ON h.id = hq.hotquestion
              JOIN t_course_modules cm
                ON cm.instance = h.id
               AND cm.module = ?
              JOIN t_context ctx
                ON ctx.instanceid = cm.id
               AND ctx.contextlevel = ?
             WHERE ctx.id = ?
        ) target ON u.id = target.userid
[array (
  0 => '20',
  1 => 70,
  2 => 184001,
)])
* line 293 of /lib/dml/moodle_read_slave_trait.php: call to moodle_database->query_end()
* line 1371 of /lib/dml/mysqli_native_moodle_database.php: call to mysqli_native_moodle_database->query_end()
* line 56 of /privacy/classes/local/request/userlist.php: call to mysqli_native_moodle_database->get_records_sql()
* line 183 of /mod/hotquestion/classes/privacy/provider.php: call to core_privacy\local\request\userlist->add_from_sql()
* line 8144 of /lib/moodlelib.php: call to mod_hotquestion\privacy\provider::get_users_in_context()
* line 578 of /privacy/classes/manager.php: call to component_class_callback()
* line 611 of /privacy/classes/manager.php: call to core_privacy\manager::component_class_callback()
* line 285 of /privacy/classes/manager.php: call to core_privacy\manager->handled_component_class_callback()
* line 451 of /admin/tool/dataprivacy/classes/expired_contexts_manager.php: call to core_privacy\manager->get_users_in_context()
* line 388 of /admin/tool/dataprivacy/classes/expired_contexts_manager.php: call to tool_dataprivacy\expired_contexts_manager->delete_expired_context()
* line 1123 of /admin/tool/dataprivacy/tests/expired_contexts_test.php: call to tool_dataprivacy\expired_contexts_manager->process_approved_deletions()
* line 1548 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to tool_dataprivacy\expired_contexts_test->test_process_course_context_with_user_in_both_lists()
* line 1154 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 94 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 728 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 904 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 661 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 144 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 97 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 98 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 122 of /vendor/bin/phpunit: call to include()


/var/www/html/lib/phpunit/classes/advanced_testcase.php:102

4) tool_dataprivacy\expired_contexts_test::test_process_course_context_with_user_in_both_lists_expired
Unexpected debugging() call detected.
Debugging: Error reading from database (Unknown column 'hqq.userid' in 'field list'

            SELECT DISTINCT u.id
            FROM t_user u
            JOIN (
            SELECT hqq.userid
              FROM t_hotquestion_questions hq
              JOIN t_hotquestion h
                ON h.id = hq.hotquestion
              JOIN t_course_modules cm
                ON cm.instance = h.id
               AND cm.module = ?
              JOIN t_context ctx
                ON ctx.instanceid = cm.id
               AND ctx.contextlevel = ?
             WHERE ctx.id = ?
        ) target ON u.id = target.userid
[array (
  0 => '20',
  1 => 70,
  2 => 184001,
)])
* line 293 of /lib/dml/moodle_read_slave_trait.php: call to moodle_database->query_end()
* line 1371 of /lib/dml/mysqli_native_moodle_database.php: call to mysqli_native_moodle_database->query_end()
* line 56 of /privacy/classes/local/request/userlist.php: call to mysqli_native_moodle_database->get_records_sql()
* line 183 of /mod/hotquestion/classes/privacy/provider.php: call to core_privacy\local\request\userlist->add_from_sql()
* line 8144 of /lib/moodlelib.php: call to mod_hotquestion\privacy\provider::get_users_in_context()
* line 578 of /privacy/classes/manager.php: call to component_class_callback()
* line 611 of /privacy/classes/manager.php: call to core_privacy\manager::component_class_callback()
* line 285 of /privacy/classes/manager.php: call to core_privacy\manager->handled_component_class_callback()
* line 451 of /admin/tool/dataprivacy/classes/expired_contexts_manager.php: call to core_privacy\manager->get_users_in_context()
* line 388 of /admin/tool/dataprivacy/classes/expired_contexts_manager.php: call to tool_dataprivacy\expired_contexts_manager->delete_expired_context()
* line 1219 of /admin/tool/dataprivacy/tests/expired_contexts_test.php: call to tool_dataprivacy\expired_contexts_manager->process_approved_deletions()
* line 1548 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to tool_dataprivacy\expired_contexts_test->test_process_course_context_with_user_in_both_lists_expired()
* line 1154 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 94 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 728 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 904 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 661 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 144 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 97 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 98 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 122 of /vendor/bin/phpunit: call to include()


/var/www/html/lib/phpunit/classes/advanced_testcase.php:102

```
Moodle version 4.2
PHP version 8.0