### PR TITLE
removing typo from tag in toolbar_reload.feature

### DIFF
--- a/tests/behat/toolbar_reload.feature
+++ b/tests/behat/toolbar_reload.feature
@@ -1,4 +1,4 @@
-67@mod @mod_hotquestion
+@mod @mod_hotquestion
 Feature: When viewing pevious rounds users can follow reload to go to current round
   In order to ensure I am on current round
   As a user


### PR DESCRIPTION
This will no longer show
`Expected Feature, but got text: "67@mod @mod_hotquestion" in file: /var/www/html/mod/hotquestion/tests/behat/toolbar_reload.feature
`
 in Behat tests.