### PR TITLE
Remove table borders in Moodle ≥ 5.0

### DIFF
--- a/tests/behat/questions_approve_not_required.feature
+++ b/tests/behat/questions_approve_not_required.feature
@@ -23,6 +23,10 @@ Feature: Users can post named or anonymous entries to hotquestion
     And the following "activities" exist:
       | activity     | name                   | intro             | course | idnumber     | submitdirections           | anonymouspost | approval |
       | hotquestion  | Test hotquestion name  | Hotquestion intro | C1     | hotquestion1 | Submit your question here: | 1             | 0        |
+    And the following "permission overrides" exist:
+      | capability                  | permission | role    | contextlevel | reference |
+      | moodle/site:accessallgroups | Allow      | teacher | System       |           |
+
   Scenario: A user posts named and anonymous entries
     # Admin User adds posts.
     Given I log in as "admin"

--- a/tests/behat/questions_post.feature
+++ b/tests/behat/questions_post.feature
@@ -23,6 +23,10 @@ Feature: Users can post anonymous or named entries to hotquestion
     And the following "activities" exist:
       | activity     | name                   | intro             | course | idnumber     | submitdirections           |
       | hotquestion  | Test hotquestion name  | Hotquestion intro | C1     | hotquestion1 | Submit your question here: |
+    And the following "permission overrides" exist:
+      | capability                  | permission | role    | contextlevel | reference |
+      | moodle/site:accessallgroups | Allow      | teacher | System       |           |
+
   Scenario: A user posts named and anonymous entries
     # Admin User adds posts.
     Given I log in as "admin"

--- a/tests/behat/questions_vote.feature
+++ b/tests/behat/questions_vote.feature
@@ -25,6 +25,10 @@ Feature: Users can vote on named or anonymous entries to hotquestion
     And the following "activities" exist:
       | activity    | name                  | intro             | course | idnumber     | submitdirections           | heatvisibility | heatlabel | heatlimit |
       | hotquestion | Test hotquestion name | Hotquestion intro | C1     | hotquestion1 | Submit your question here: | 1              | Heat      | 5         |
+    And the following "permission overrides" exist:
+      | capability                  | permission | role    | contextlevel | reference |
+      | moodle/site:accessallgroups | Allow      | teacher | System       |           |
+
   Scenario: A user follows vote to increase heat
     # Student 1 adds posts.
     Given I log in as "student1"

--- a/view.php
+++ b/view.php
@@ -299,7 +299,7 @@ if (!$ajax) {
     }
 
     // 20230522 Added a single row table to make both group and viewunapproved preference drop down menus work.
-    echo '<table style="width:100%"><tr><td style="width:25%>';
+    echo '<table style="width:100%" class="table-reboot"><tr><td style="width:25%>';
     // Print group information (A drop down box will be displayed if the user
     // is a member of more than one group, or has access to all groups).
     echo groups_print_activity_menu($cm, $CFG->wwwroot.'/mod/hotquestion/view.php?id='.$cm->id);


### PR DESCRIPTION
There is an unneccessary line around a table cell.
Note this needs Moodle 5.0.3, since "table-reboot" class is introduced by that version.