### PR TITLE
Detect button::BODY_OUTLINE reliably.

### DIFF
--- a/classes/courseformat/overview.php
+++ b/classes/courseformat/overview.php
@@ -52,7 +52,10 @@ class overview extends \core_courseformat\activityoverviewbase {
 
         $text = get_string('view');
 
-        if (defined('button::BODY_OUTLINE')) {
+        if (
+            class_exists(button::class) &&
+            (new \ReflectionClass(button::class))->hasConstant('BODY_OUTLINE')
+        ) {
             $bodyoutline = button::BODY_OUTLINE;
             $buttonclass = $bodyoutline->classes();
         } else {


### PR DESCRIPTION
All activities use button::BODY_OUTLINE, not button::SECONDARY_OUTLINE, actually.
Moodle 5.0 which hasn't button::BODY_OUTLINE will use button::SECONDARY_OUTLINE.

Previous implemented detection with `if (defined('button::BODY_OUTLINE'))` was not reliable.